### PR TITLE
Refactored Optimization part, added info and reduced space

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -316,47 +316,49 @@ Neurons: $F_\sigma(x;w) = \sigma(w_0 + \sum_{i=1}^M{x_iw_i})$. Output: linear re
 Translation invariance of images $\rightarrow$ neurons compute same fct, shift invariant filters; weights defined as filter masks, e.g. convolution: $F_{n,m}(x;w) = \sigma(b + \sum_{k=-2}^2\sum_{l=-2}^{2}{w_{k,l}x_{n+k,m+1}})$. To reduce dimension of convolution, use \{max, avg\}-pooling 
 
 \section{Optimization}
-Gradient of $f: \mathbb{R}^D \to \mathbb{R}$ is $\nabla f(\mathbf{x}) := \left( \frac{\partial f(\mathbf{x})}{\partial \mathbf{x}_1}, \ldots, \frac{\partial f(\mathbf{x})}{\partial \mathbf{x}_D} \right)^\top \in \mathbb{R}^D$
 
-\subsection{Coordinate Descent}
-Update one coordinate (the $d$-th), others are fixed.
+\subsection{Coordinate Descent (update the $d$-th coord. per step)}
 \begin{inparaenum}[\color{red} 1.]
-	\item Init: $\mathbf{x}^{(0)} \in \mathbb{R}^D$
-	\item For $t = 0 \ \text{to} \ \mathit{maxIters}$:
-	\item uniformly sample $d \sim \{1, \ldots, D\}$
-	\item $u^\star = \argmin_{u \in \mathbb{R}} f(x_1^{(t)}, \ldots, x_{d-1}^{(t)}, u, x_{d+1}^{(t)}, \ldots, x_D^{(t)})$
+	\item init: $\mathbf{x}^{(0)} \in \mathbb{R}^D$
+	\item for $t = 0 \ \text{to} \ \mathit{maxIter}$:
+	\item sample u.a.r. $d \sim \{1, \ldots, D\}$
+	\item $u^\star = \argmin_{u \in \mathbb{R}} f(x_1^{(t)}, .., x_{d-1}^{(t)}, u, x_{d+1}^{(t)}, .., x_D^{(t)})$
 	\item $\mathbf{x}_d^{(t+1)} = u^\star$ and $\mathbf{x}_i^{(t+1)} = \mathbf{x}_i^{(t)}$ for $i \neq d$
 \end{inparaenum}
 
-\subsection{Gradient Descent}
+\subsection{Gradient Descent (or Deepest Descent)}
+\textbf{Gradient}: $\nabla f(\mathbf{x}) := \left( \frac{\partial f(\mathbf{x})}{\partial \mathbf{x}_1}, \ldots, \frac{\partial f(\mathbf{x})}{\partial \mathbf{x}_D} \right)^\top$
 \begin{inparaenum}[\color{red} 1.]
-	\item Init: $\mathbf{x}^{(0)} \in \mathbb{R}^D$, stepsize usually $\gamma \approx \frac{1}{t}$
-	\item For $t = 0 \ \text{to} \ \mathit{maxIters}$: $\mathbf{x}^{(t+1)} = \mathbf{x}^{(t)} - \gamma \nabla f(\mathbf{x}^{(t)})$
+	\item init: $\mathbf{x}^{(0)} \in \mathbb{R}^D$
+	\item for $t = 0 \ \text{to} \ \mathit{maxIter}$: $\mathbf{x}^{(t+1)} = \mathbf{x}^{(t)} - \gamma \nabla f(\mathbf{x}^{(t)})$, usually $\gamma \approx \frac{1}{t}$
 \end{inparaenum}
 
-\subsection{Stochastic Gradient Descent}
-Assume additive objective; $f(x) = \frac{1}{N}\sum_{n=1}^{N}f_n(x)$
+\subsection{Stochastic Gradient Descent (SGD)}
+Assume \textbf{Additive Objective}; $f(x) = \frac{1}{N}\sum_{n=1}^{N}f_n(x)$
 \begin{inparaenum}[\color{red} 1.]
-	\item Init: $\mathbf{x}^{(0)} \in \mathbb{R}^D$
-	\item For $t = 0 \ \text{to} \ \mathit{maxIters}$:
-	\item sample u.a.r. $n \sim \{1, \ldots, D\}$
-	\item $\mathbf{x}^{(t+1)} = \mathbf{x}^{(t)} - \gamma \nabla f_n(\mathbf{x}^{(t)})$, usually $\gamma \approx \frac{1}{t}$. 
+	\item init: $\mathbf{x}^{(0)} \in \mathbb{R}^D$
+	\item for $t = 0 \ \text{to} \ \mathit{maxIter}$:
+	\item sample u.a.r. $n \sim \{1, \ldots, N\}$
+	\item $\mathbf{x}^{(t+1)} = \mathbf{x}^{(t)} - \gamma \nabla f_n(\mathbf{x}^{(t)})$, usually stepsize $\gamma \approx \frac{1}{t}$. 
 \end{inparaenum}
 
-\subsection{Projected Gradient Descent}
-In the gradient update step use a projection onto constraint space $Q \subseteq \mathbb{R}^D$ with $P_Q(\mathbf{x}) = \argmin_{y \in Q} \|\mathbf{y} - \mathbf{x}\|$: $\mathbf{x}^{(t+1)} = P_Q[\mathbf{x}^{(t)} - \gamma \nabla f(\mathbf{x}^{(t)})]$. $\mathbf{x}^{(t+1)}$ unique if $Q$ convex.
+\subsection{Projected Gradient Descent (Constrained Opt.)}
+minimize $f(x)$, $x \in Q$ (constraint).
+\textbf{Project} $x$ onto $Q$: $P_Q(\mathbf{x}) = \argmin_{y \in Q} \|\mathbf{y} - \mathbf{x}\|$,
+\textbf{Projected Gradient Update}: $\mathbf{x}^{(t+1)} = P_Q[\mathbf{x}^{(t)} - \gamma \nabla f(\mathbf{x}^{(t)})]$,
+$\mathbf{x}^{(t+1)}$ is unique if $Q$ convex.
 
 \subsection{Lagrangian Multipliers}
-Minimize  $f(\mathbf{x})$ subject to $g_i(\mathbf{x}) \leq 0,\ i = 1, \ldots, m$ and $h_i(\mathbf{x}) = \mathbf{a}_i^\top \mathbf{x} - b_i = 0,\ i = 1, \ldots, p$.
+Minimize  $f(\mathbf{x})$ s.t. $g_i(\mathbf{x}) \leq 0,\ i = 1, .., m$ (\textbf{inequality constr.}) and $h_i(\mathbf{x}) = \mathbf{a}_i^\top \mathbf{x} - b_i = 0,\ i = 1, .., p$ (\textbf{equality constraint})
 \begin{compactdesc}
 	\item[Lagrangian:] $L(\mathbf{x}, \boldsymbol{\lambda}, \boldsymbol{\nu}) := f(\mathbf{x}) + \sum_{i=1}^m \lambda_i g_i(\mathbf{x}) + \sum_{i=1}^p \nu_i h_i(\mathbf{x})$
 	\item[Dual function:] $D(\boldsymbol{\lambda}, \boldsymbol{\nu}) := \inf_{\mathbf{x}} L(\mathbf{x}, \boldsymbol{\lambda}, \boldsymbol{\nu}) \in \mathbb{R}$
-	\item[Dual Problem:] $\max_{\boldsymbol{\lambda}, \boldsymbol{\nu}} D(\boldsymbol{\lambda}, \boldsymbol{\nu})$ s.t. $\boldsymbol{\lambda} \geq \mathbf{0}$. Note that $\max_{\boldsymbol{\lambda}, \boldsymbol{\nu}} D(\boldsymbol{\lambda}, \boldsymbol{\nu}) \le \min_x{f(x)}$. Equality if $dom\ f$ and $f$ convex.
+	\item[Dual Problem:] $\max_{\boldsymbol{\lambda}, \boldsymbol{\nu}} D(\boldsymbol{\lambda}, \boldsymbol{\nu})$ s.t. $\boldsymbol{\lambda} \geq \mathbf{0}$. Note: $\max_{\boldsymbol{\lambda}, \boldsymbol{\nu}} D(\boldsymbol{\lambda}, \boldsymbol{\nu}) \le \min_x{f(x)}$, equality if $dom\ f$ and $f$ convex
 \end{compactdesc}
 
-\subsection{Convex Functions}
-A function $f : \mathbb{R}^D \rightarrow \mathbb{R}$ is convex if $dom\ f$ is a convex set and if $\forall \mathbf{x}, \mathbf{y} \in dom\ f$, and $\alpha$ with $0 \leq \alpha \leq 1$, we have $f(\alpha \mathbf{x} + (1 - \alpha)\mathbf{y}) \leq \alpha f(\mathbf{x}) + (1-\alpha)f(\mathbf{y})$. local $\min = $ global $\min$ and all above algos converge with $f(x^{(t)}) - f(x^*) \le \frac{c}{t}$. 
-%E.g: $\textbf{a)^\top\textbf{x} + b, \exp{\alpha x}$
+\subsection{Convex Optimization}
+$f : \mathbb{R}^D \rightarrow \mathbb{R}$ is convex, if $dom\ f$ is a convex set, and if $\forall \mathbf{x}, \mathbf{y} \in dom\ f$, and for $0 \leq \alpha \leq 1$: $f(\alpha \mathbf{x} + (1 - \alpha)\mathbf{y}) \leq \alpha f(\mathbf{x}) + (1-\alpha)f(\mathbf{y})$. local=global min, \textbf{Convergence}: $f(x^{(t)}) - f(x^*) \le \frac{c}{t}$. 
+\textbf{Subgradient} $g \in \mathbb{R}^D$ of $f$ at $x$: $f(y) \geq f(x) + g^\top(y-x) \ \forall y$
 
 \section{Sparse Coding}
 Reconstruction error: $\|\mathbf{x}-\mathbf{\hat{x}}\|^2 = \sum_{d\notin\sigma}\| \langle\mathbf{x},\mathbf{u}_d \rangle \cdot \mathbf{u}_d \|^2 = \sum_{d\notin\sigma}\langle\mathbf{x},\mathbf{u}_d\rangle ^2$


### PR DESCRIPTION
- moved Gradient to Gradient Descent subsection to save space (and IMO it belongs there)
- shortened Coordinate Descent by moving goal to title
- Projected Gradient Descent is now more clear
- added inequality- and equality constraint terms to Lagrangian Multipliers
- Simplified Convex Functions subsection and added Subgradient
